### PR TITLE
Got rid of env_path as a variable. 

### DIFF
--- a/srcs/myshell.c
+++ b/srcs/myshell.c
@@ -31,7 +31,6 @@ A very simple shell program.
 #define MAX_BUFFER_SIZE 128
 #define MAX_ARGS 16
 
-list_element *env_path = NULL;
 char *prefix = NULL;
 
 void built_in_cmd_message (const char *name) {
@@ -66,8 +65,6 @@ void signal_handler (int signal) {
 }
 
 int main (int argc, char *argv[]) {
-
-    env_path = get_path();
 
     char input[MAX_BUFFER_SIZE];
     char *args[MAX_ARGS];
@@ -122,7 +119,6 @@ int main (int argc, char *argv[]) {
         if (strcmp(args[0], "exit") == 0) {
 
             built_in_cmd_message("exit");
-            free_list(env_path);
             free_previous_dir();
             free(prefix);
             exit(0);

--- a/srcs/which.c
+++ b/srcs/which.c
@@ -25,14 +25,14 @@ ENOENT - None of the commands were found on the PATH.
 #include "path.h"
 #include "which.h"
 
-extern list_element *env_path;
-
 list_element *which (int argc, char *argv[], bool show_all) {
 
     if (argc <= 1) {
         errno = EINVAL;
         return NULL;
     }
+
+    list_element *env_path = get_path();
 
     list_element *head = malloc(sizeof(list_element));
     list_element *current = head;
@@ -64,6 +64,8 @@ list_element *which (int argc, char *argv[], bool show_all) {
             current_env_path = current_env_path->next;
         }
     }
+
+    free_list(env_path);
 
     if (prev) {
         // Free current because its space was allocated but never initialized.


### PR DESCRIPTION
It's easier to just allocate/free the list as needed.